### PR TITLE
Release/v0.0.1

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
     "recommendations": [
+        "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.1-develop] - 2026-01-24
+## [0.0.1-release] - 2026-01-24
 
 ### Added
 - **Firmware Versioning**: Introduced a versioning system in `include/param.h` (Major, Minor, Patch, Branch).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1-develop] - 2026-01-24
+
+### Added
+- **Firmware Versioning**: Introduced a versioning system in `include/param.h` (Major, Minor, Patch, Branch).
+- **Serial Reset**: Added functionality to reset the ESP32 via serial commands.
+- **Project Setup**: Configured `.vscode/extensions.json` with recommended extensions (PlatformIO, C++ tools) for optimal development.
+- **Hardware ID**: Defined `BOARD_VERSION` for the ESP32-3248S035 hardware.
+
+### Changed
+- **Documentation Overhaul**: 
+    - Redesigned `README.md` with professional headers and emojis.
+    - Added a modular "Firmware Design" section documenting Application, Web Server, Display, Network, and Storage interfaces.
+    - Refined "Build Pre-requisites" to clearly outline manual `TFT_eSPI` and `LVGL` configuration steps.
+- **Repository Maintenance**: 
+    - Cleaned up the `develop` branch history.
+    - Aborted problematic rebases and established a clean, force-pushed state for the branch.
+
+### Fixed
+- **Push Conflicts**: Resolved non-fast-forward push errors and merged diverging remote changes.
+- **Library Configurations**: Ensured build flags in `platformio.ini` correctly include the necessary header paths and debug levels.

--- a/include/param.h
+++ b/include/param.h
@@ -4,7 +4,7 @@
 #define FIRMWARE_VERSION_MAJOR 0
 #define FIRMWARE_VERSION_MINOR 0
 #define FIRMWARE_VERSION_PATCH 1
-#define FIRMWARE_VERSION_BRANCH "develop" // Branch number (0 for main branch, 1 for dev branch, etc.)
+#define FIRMWARE_VERSION_BRANCH "release" // Branch number (0 for main branch, 1 for dev branch, etc.)
 
 #define FIRMWARE_VERSION {FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, FIRMWARE_VERSION_PATCH} // Firmware version array
 

--- a/include/param.h
+++ b/include/param.h
@@ -1,0 +1,13 @@
+#ifndef PARAMS_H
+#define PARAMS_H
+
+#define FIRMWARE_VERSION_MAJOR 0
+#define FIRMWARE_VERSION_MINOR 0
+#define FIRMWARE_VERSION_PATCH 1
+#define FIRMWARE_VERSION_BRANCH "develop" // Branch number (0 for main branch, 1 for dev branch, etc.)
+
+#define FIRMWARE_VERSION {FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, FIRMWARE_VERSION_PATCH} // Firmware version array
+
+#define BOARD_VERSION "ESP32-3248S035" //
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include "param.h"
 
 // #define USE_EX
 
@@ -19,11 +20,16 @@ Display_ST7796 display;
 // Network_Wifi network("AksesPoin_eFishery", "efishery2516!");
 Network_Wifi network("Angkasa-Timelapse", "1234567890");
 
+const char *main_tag = "main";
+
 GifDisplayer app(stg, display, network);
 
 void setup()
 {
     Serial.begin(115200);
+    ESP_LOGI(main_tag, "Board starting...");
+    ESP_LOGI(main_tag, "Firmware version: %d.%d.%d-%s", FIRMWARE_VERSION_MAJOR, FIRMWARE_VERSION_MINOR, FIRMWARE_VERSION_PATCH, FIRMWARE_VERSION_BRANCH);
+    ESP_LOGI(main_tag, "Board version: %s", BOARD_VERSION);
     delay(1000);
 
     if (!app.init())


### PR DESCRIPTION
This pull request introduces a versioning system for the firmware, improves project documentation, and enhances development environment configuration. It also adds mechanisms for hardware identification and serial-based resets, and resolves several repository and build configuration issues.

**Firmware Versioning and Hardware Identification**

* Introduced a versioning system in `include/param.h`, defining major, minor, patch, and branch for the firmware, and added a `BOARD_VERSION` identifier for the ESP32-3248S035 hardware.
* Integrated the new versioning and board information into the startup log output in `src/main.cpp`.

**Development Environment and Project Setup**

* Updated `.vscode/extensions.json` to recommend the `pioarduino-ide` extension alongside PlatformIO, improving the developer experience.

**Documentation and Repository Maintenance**

* Added a `CHANGELOG.md` following the Keep a Changelog format, documenting all notable changes, including versioning, hardware ID, serial reset functionality, documentation improvements, and repository maintenance actions.
* Overhauled the `README.md` (as described in the changelog) to provide clearer build instructions and modular documentation (referenced in changelog, not shown directly in this diff).

**Codebase Integration**

* Included the new `param.h` header in `src/main.cpp` to make version and board information available throughout the codebase.